### PR TITLE
fix build against `gcc-13` (missing `<cstdint>` include)

### DIFF
--- a/src/graph_plain.h
+++ b/src/graph_plain.h
@@ -34,6 +34,7 @@
 #define LOUVAIN_GRAPHPLAIN_H
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/src/louvain_communities.cpp
+++ b/src/louvain_communities.cpp
@@ -26,6 +26,7 @@
 
 #include "louvain_communities.h"
 
+#include <cstdint>
 #include <unistd.h>
 #include "graph_binary.h"
 #include "graph_plain.h"


### PR DESCRIPTION
Withouit the change the build against `gcc-13` fails as:

    /build/source/src/louvain_communities.cpp: At global scope:
    /build/source/src/louvain_communities.cpp:60:5: error: 'uint32_t' does not name a type
       60 |     uint32_t verbosity = 0;
          |     ^~~~~~~~
    /build/source/src/louvain_communities.cpp:44:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       43 | #include "GitSHA1.h"
      +++ |+#include <cstdint>
       44 |